### PR TITLE
check node.attrs.class is string

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ module.exports = function posthtmlCustomElements(options) {
                         node.tag = node.attrs.tag;
                         delete node.attrs.tag;
                     }
+                    
+                    if (typeof node.attrs.class !== 'string') {
+                        node.attrs.class = '';
+                    }
 
                     var classes = node.attrs.class.split(' ');
                     if(classes.indexOf(tag) === -1) {


### PR DESCRIPTION
Run..

```javascript
import TodoItemList from './components/TodoItemList.js';

const ele = TodoItemList.create();

console.log(ele.innerHTML);

document.getElementById('app').appendChild(ele);
```

Throw Error
> `index.js:34 Uncaught TypeError: Cannot read property 'split' of undefined`

---

If the class attribute is empty in the input string, `node.attrs.class` is `undefined`.

**PostHTML version: 0.11.3**
hum...