### PR TITLE
[fix]: Update the tag process logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Skip HTML5 tag
 ```
 
 ```html
-<div class="header">Test</div>
+<header>Test</header>
 ```
 
 ## Support

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function posthtmlCustomElements(options) {
             if(node.tag) {
                 var tag = node.tag;
 
-                if (skipTags.indexOf(tag) !== -1 || html5tags.indexOf(tag.toLowerCase()) === -1) {
+                if (skipTags.indexOf(tag) === -1 && html5tags.indexOf(tag.toLowerCase()) === -1) {
 
                     node.tag = defaultTag;
 

--- a/test/test.js
+++ b/test/test.js
@@ -91,7 +91,7 @@ it('Class inside', function(done) {
         });
         it('skipTags', function(done) {
             var html = '<header class="custom">Test</header>';
-            var referense = '<div class="header custom">Test</div>';
+            var referense = '<header class="custom">Test</header>';
             test(html, referense, { skipTags: ['header']}, done);
         });
     });


### PR DESCRIPTION
From the meaning of variable name "skipTags", it seems if the tag comes under the skiptags array or if it falls under any existing html5 tag, the processing should be skipped.
